### PR TITLE
Improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:mainline-alpine
 MAINTAINER Tarik Benammar <tarik@benammar.com>
 
 #We need to install bash to easily handle arrays
@@ -16,6 +16,7 @@ RUN rm -f /var/log/nginx/* && \
 
 # fail2ban setup
 RUN rm /etc/fail2ban/jail.d/*
+RUN rm -rf /etc/fail2ban/filter.d/*
 COPY fail2ban/jail.local /etc/fail2ban/jail.d/
 COPY fail2ban/filter.d/* /etc/fail2ban/filter.d/
 RUN mkdir -p /var/run/fail2ban

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,191 +1,101 @@
 #!/bin/bash
+# Prevent script from failing on minor errors during setup
+set -e
 
-# Validate environment variables
-
+# --- 1. Validate environment variables ---
 MISSING=""
-
-if [ "${LE_DOMAIN}" == "" ]; then
-  if  [  "${SSL_DOMAIN}" == "" ]; then
+if [ -z "${LE_DOMAIN}" ] && [ -z "${SSL_DOMAIN}" ]; then
     MISSING="MISSING LE_DOMAIN or SSL_DOMAIN variable"
-  fi 
 fi
 
 [ -z "${UPSTREAM}" ] && MISSING="${MISSING} UPSTREAM"
 
-set -eo pipefail
-
 # Default other parameters
 SERVER=""
 [ -n "${STAGING:-}" ] && SERVER="--server https://acme-staging.api.letsencrypt.org/directory"
-
 [ -n "${LE_DOMAIN:-}" ] && [ -z "${EMAIL}" ] && MISSING="${MISSING} EMAIL"
 
-if [ "${MISSING}" != "" ]; then
-  echo "Missing required environment variables:" >&2
-  echo " ${MISSING}" >&2
-  exit 1
+if [ -n "${MISSING}" ]; then
+    echo "Error: ${MISSING}" >&2
+    exit 1
 fi
 
-#Processing LE_DOMAIN into an array
-DOMAINSARRAY=($(echo "${LE_DOMAIN}" | awk -F ";" '{for(i=1;i<=NF;i++) print $i;}'))
-echo "Provided domains"
-printf "%s\n" "${DOMAINSARRAY[@]}"
+# --- 2. Prepare Filesystem & Logs ---
+# Fail2Ban will CRASH if these files don't exist on start
+mkdir -p /var/log/nginx /var/run/fail2ban /etc/nginx/vhosts /etc/letsencrypt/webrootauth
+touch /var/log/nginx/access.log /var/log/nginx/error.log
+rm -f /var/run/fail2ban/fail2ban.sock # Clean up stale sockets from previous crashes
 
-# Generate strong DH parameters for nginx, if they don't already exist.
+# Process domains into array
+IFS=';' read -r -a DOMAINSARRAY <<< "${LE_DOMAIN}"
+echo "Configuring for domains: ${DOMAINSARRAY[*]}"
+
+# --- 3. Diffie-Hellman Parameters ---
 if [ ! -f /etc/ssl/dhparams.pem ]; then
-  if [ -f /cache/dhparams.pem ]; then
-    cp /cache/dhparams.pem /etc/ssl/dhparams.pem
-  else
-    openssl dhparam -out /etc/ssl/dhparams.pem 2048
-   # Cache to a volume for next time?
-    if [ -d /cache ]; then
-     cp /etc/ssl/dhparams.pem /cache/dhparams.pem
+    if [ -f /cache/dhparams.pem ]; then
+        cp /cache/dhparams.pem /etc/ssl/dhparams.pem
+    else
+        echo "Generating DH parameters (2048 bit)... this may take a moment."
+        openssl dhparam -out /etc/ssl/dhparams.pem 2048
+        [ -d /cache ] && cp /etc/ssl/dhparams.pem /cache/dhparams.pem
     fi
-  fi
 fi
 
-#create temp file storage
-mkdir -p /var/cache/nginx
-chown nginx:nginx /var/cache/nginx
+# --- 4. Template Rendering ---
+echo "Rendering nginx.conf"
+sed -e "s/\${DOMAIN}/${DOMAIN}/g" -e "s/\${UPSTREAM}/${UPSTREAM}/" /templates/nginx.conf > /etc/nginx/nginx.conf
 
-mkdir -p /var/tmp/nginx
-chown nginx:nginx /var/tmp/nginx
-
-#create vhost directory
-mkdir -p /etc/nginx/vhosts/
-
-# Process the nginx.conf with raw values of $DOMAIN and $UPSTREAM to ensure backward-compatibility
-  dest="/etc/nginx/nginx.conf"
-  echo "Rendering template of nginx.conf"
-  sed -e "s/\${DOMAIN}/${DOMAIN}/g" \
-      -e "s/\${UPSTREAM}/${UPSTREAM}/" \
-/templates/nginx.conf > "$dest"
-
-if [ "${SSL_DOMAIN}" != "" ]; then
-
- # Process templates
- letscmd=""
- dest="/etc/nginx/vhosts/$(basename "${SSL_DOMAIN}").conf"
- src="/templates/vhost.sample.conf"
-
- if [ -r /configs/"${SSL_DOMAIN}".conf ]; then
-   echo "Manual configuration found for $t"
-   src="/configs/${SSL_DOMAIN}.conf"
- fi
-
- echo "Rendering template $src in $dest"
- sed -e "s/\${DOMAIN}/${SSL_DOMAIN}/g" \
-  	    -e "s/\${UPSTREAM}/${UPSTREAM}/" \
- 	    -e "s/\${PATH}/${SSL_DOMAIN}/" \
-	    "$src" > "$dest"
-
- if [ ! -n "${SSL_DOMAIN:-}" ]; then
-   echo Ready
-   # Launch nginx in the foreground
-   /usr/sbin/nginx -g "daemon off;"
-   exit 
- fi
+# Render SSL vhosts
+if [ -n "${SSL_DOMAIN}" ]; then
+    dest="/etc/nginx/vhosts/$(basename "${SSL_DOMAIN}").conf"
+    src="/templates/vhost.sample.conf"
+    [ -r "/configs/${SSL_DOMAIN}.conf" ] && src="/configs/${SSL_DOMAIN}.conf"
+    
+    sed -e "s/\${DOMAIN}/${SSL_DOMAIN}/g" -e "s/\${UPSTREAM}/${UPSTREAM}/" -e "s/\${PATH}/${SSL_DOMAIN}/" "$src" > "$dest"
 fi
 
-# Process LE SSL template
+# --- 5. Let's Encrypt Logic ---
+if [ -n "${LE_DOMAIN}" ]; then
+    letscmd=""
+    for t in "${DOMAINSARRAY[@]}"; do
+        dest="/etc/nginx/vhosts/$(basename "${t}").conf"
+        src="/templates/vhost.le-ssl.sample.conf"
+        [ -r "/configs/${t}.conf" ] && src="/configs/${t}.conf"
+        
+        sed -e "s/\${DOMAIN}/${t}/g" -e "s/\${UPSTREAM}/${UPSTREAM}/" -e "s/\${PATH}/${DOMAINSARRAY[0]}/" "$src" > "$dest"
+        letscmd="$letscmd -d $t"
+    done
 
-if [ "${LE_DOMAIN}" != "" ]; then
-
-  letscmd=""
-  for t in "${DOMAINSARRAY[@]}"
-  do
-    dest="/etc/nginx/vhosts/$(basename "${t}").conf"
-    src="/templates/vhost.le-ssl.sample.conf"
-
-    if [ -r /configs/"${t}".conf ]; then
-      echo "Manual configuration found for $t"
-      src="/configs/${t}.conf"
+    # Check for SAN changes
+    fresh=false
+    if [ ! -f /etc/letsencrypt/san_list ] || [ "$(cat /etc/letsencrypt/san_list)" != "${LE_DOMAIN}" ]; then
+        echo "SAN list changed or new install. Resetting certs."
+        rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
+        fresh=true
     fi
 
-    echo "Rendering template $src of $t in $dest"
-    sed -e "s/\${DOMAIN}/${t}/g" \
-        -e "s/\${UPSTREAM}/${UPSTREAM}/" \
-        -e "s/\${PATH}/${DOMAINSARRAY[0]}/" \
-        "$src" > "$dest"
+    if [ "$fresh" = true ]; then
+        echo "Requesting initial certificates..."
+        certbot certonly $letscmd --standalone --non-interactive --agree-tos --email "${EMAIL}" ${SERVER} --expand
+        echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
+    fi
 
+    # Update cli.ini (Removed the expired DST Root CA X3 reference)
+    echo "preferred-chain = ISRG Root X1" > /etc/letsencrypt/cli.ini
 
-    #prepare the letsencrypt command arguments
-    letscmd="$letscmd -d $t "
-  done
-
-echo $letscmd
-
-# Check if the SAN list has changed
- if [ ! -f /etc/letsencrypt/san_list ]; then
-  cat <<EOF >/etc/letsencrypt/san_list
-  "${LE_DOMAIN}"
+    # Setup Renewal Cron
+    cat <<EOF > /etc/periodic/monthly/reissue
+#!/bin/bash
+certbot renew --webroot -w /etc/letsencrypt/webrootauth/ --post-hook "nginx -s reload"
 EOF
-   fresh=true
- else
-   old_san=$(cat /etc/letsencrypt/san_list)
-   if [ "${LE_DOMAIN}" != "${old_san}" ]; then
-     fresh=true
-   else
-     fresh=false
-   fi
- fi
+    chmod +x /etc/periodic/monthly/reissue
+    /usr/sbin/crond -b # Start cron in background
+fi
 
-# Initial certificate request, but skip if cached
-   if [ $fresh = true ]; then
-     echo "The SAN list has changed, removing the old certificate and ask for a new one."
-     rm -rf /etc/letsencrypt/{live,archive,keys,renewal}
+# --- 6. Launch Services ---
+echo "Starting Fail2Ban..."
+# -b starts in background, -x ensures it cleans up previous server remains
+fail2ban-server -b -x
 
-    echo "certbot certonly "${letscmd}" \
-     --standalone --text \
-     "${SERVER}" \
-     --email "${EMAIL}" --agree-tos \
-     --expand " > /etc/nginx/lets
-
-     echo "Running initial certificate request... "
-     /bin/bash /etc/nginx/lets
-   fi
-
-#update the stored SAN list
- echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
-
-#Create the renewal directory (containing well-known challenges)
- mkdir -p /etc/letsencrypt/webrootauth/
-
- #Preparing for the ISRG Root transition (January 11 2021)
- echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
-
-# Template a cronjob to reissue the certificate with the webroot authenticator
- echo "Creating a cron job to keep the certificate updated"
-  cat <<EOF >/etc/periodic/monthly/reissue
-#!/bin/sh
-
-set -euo pipefail
-
-# Certificate reissue
-certbot certonly --force-renewal \
---webroot --text \
--w /etc/letsencrypt/webrootauth/ \
-${letscmd} \
-${SERVER} \
---email "${EMAIL}" --agree-tos \
---expand
-
-# Reload nginx configuration to pick up the reissued certificates
-/usr/sbin/nginx -s reload
-EOF
-
- chmod +x /etc/periodic/monthly/reissue
-
-# Kick off cron to reissue certificates as required
-# Background the process and log to stderr
- /usr/sbin/crond -f -d 8 &
-
-fi #LE_DOMAIN Section
-
-echo Ready
-
-# Run fail2ban
-fail2ban-client -b -x start
-
-# Launch nginx in the foreground
-/usr/sbin/nginx -g "daemon off;"
+echo "Starting Nginx..."
+exec nginx -g "daemon off;"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,6 +145,9 @@ EOF
      /bin/bash /etc/nginx/lets
    fi
 
+#Preparing for the ISRG Root transition (January 11 2021)
+ echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
+
 #update the stored SAN list
  echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,15 +145,15 @@ EOF
      /bin/bash /etc/nginx/lets
    fi
 
-#Preparing for the ISRG Root transition (January 11 2021)
- echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
-
 #update the stored SAN list
  echo "${LE_DOMAIN}" > /etc/letsencrypt/san_list
 
 #Create the renewal directory (containing well-known challenges)
  mkdir -p /etc/letsencrypt/webrootauth/
-:
+
+ #Preparing for the ISRG Root transition (January 11 2021)
+ echo "preferred-chain = DST Root CA X3" > /etc/letsencrypt/cli.ini
+
 # Template a cronjob to reissue the certificate with the webroot authenticator
  echo "Creating a cron job to keep the certificate updated"
   cat <<EOF >/etc/periodic/monthly/reissue

--- a/fail2ban/filter.d/nginx-badbots.conf
+++ b/fail2ban/filter.d/nginx-badbots.conf
@@ -7,10 +7,11 @@
 
 [Definition]
 
-badbotscustom = EmailCollector|WebEMailExtrac|TrackBack/1\.02|sogou music spider|SEMrushBot
+badbotscustom = EmailCollector|WebEMailExtrac|TrackBack/1\.02|sogou music spider|SEMrushBot|GPTBot|Barkrowler|AhrefsBot|DotBot|AliyunSecBot|GeedoShopProductFinder
+
 badbots = Atomic_Email_Hunter/4\.0|atSpider/1\.0|autoemailspider|bwh3_user_agent|China Local Browse 2\.6|ContactBot/0\.2|ContentSmartz|DataCha0s/2\.0|DBrowse 1\.4b|DBrowse 1\.4d|Demo Bot DOT 16b|Demo Bot Z 16b|DSurf15a 01|DSurf15a 71|DSurf15a 81|DSurf15a VA|EBrowse 1\.4b|Educate Search VxB|EmailSiphon|EmailSpider|EmailWolf 1\.00|ESurf15a 15|ExtractorPro|Franklin Locator 1\.8|FSurf15a 01|Full Web Bot 0416B|Full Web Bot 0516B|Full Web Bot 2816B|Guestbook Auto Submitter|Industry Program 1\.0\.x|ISC Systems iRc Search 2\.1|IUPUI Research Bot v 1\.9a|LARBIN-EXPERIMENTAL \(efp@gmx\.net\)|LetsCrawl\.com/1\.0 +http\://letscrawl\.com/|Lincoln State Web Browser|LMQueueBot/0\.2|LWP\:\:Simple/5\.803|Mac Finder 1\.0\.xx|MFC Foundation Class Library 4\.0|Microsoft URL Control - 6\.00\.8xxx|Missauga Locate 1\.0\.0|Missigua Locator 1\.9|Missouri College Browse|Mizzu Labs 2\.2|Mo College 1\.9|MVAClient|Mozilla/2\.0 \(compatible; NEWT ActiveX; Win32\)|Mozilla/3\.0 \(compatible; Indy Library\)|Mozilla/3\.0 \(compatible; scan4mail \(advanced version\) http\://www\.peterspages\.net/?scan4mail\)|Mozilla/4\.0 \(compatible; Advanced Email Extractor v2\.xx\)|Mozilla/4\.0 \(compatible; Iplexx Spider/1\.0 http\://www\.iplexx\.at\)|Mozilla/4\.0 \(compatible; MSIE 5\.0; Windows NT; DigExt; DTS Agent|Mozilla/4\.0 efp@gmx\.net|Mozilla/5\.0 \(Version\: xxxx Type\:xx\)|NameOfAgent \(CMS Spider\)|NASA Search 1\.0|Nsauditor/1\.x|PBrowse 1\.4b|PEval 1\.4b|Poirot|Port Huron Labs|Production Bot 0116B|Production Bot 2016B|Production Bot DOT 3016B|Program Shareware 1\.0\.2|PSurf15a 11|PSurf15a 51|PSurf15a VA|psycheclone|RSurf15a 41|RSurf15a 51|RSurf15a 81|searchbot admin@google\.com|ShablastBot 1\.0|snap\.com beta crawler v0|Snapbot/1\.0|Snapbot/1\.0 \(Snap Shots&#44; +http\://www\.snap\.com\)|sogou develop spider|Sogou Orion spider/3\.0\(+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sogou spider|Sogou web spider/3\.0\(+http\://www\.sogou\.com/docs/help/webmasters\.htm#07\)|sohu agent|SSurf15a 11 |TSurf15a 11|Under the Rainbow 2\.2|User-Agent\: Mozilla/4\.0 \(compatible; MSIE 6\.0; Windows NT 5\.1\)|VadixBot|WebVulnCrawl\.unknown/1\.0 libwww-perl/5\.803|Wells Search II|WEP Search 00
 
-failregex = ^<HOST> -.*"(GET|POST|HEAD).*HTTP.*"(?:%(badbots)s|%(badbotscustom)s)"$
+failregex = ^<HOST> -.*"(?:GET|POST|HEAD)[^"]*HTTP[^"]*" \d+ \d+ "[^"]*" ".*(?:%(badbots)s|%(badbotscustom)s).*"$
 
 ignoreregex =
 

--- a/templates/vhost.le-ssl.sample.conf
+++ b/templates/vhost.le-ssl.sample.conf
@@ -2,9 +2,10 @@ server {
     listen 443 ssl http2;
     server_name ${DOMAIN};
 
-    if ($http_user_agent ~ ".*SEMrushBot.*") {
-      return 301 "http://semrush.com/";
+    if ($http_user_agent ~* (thesis-research-bot|Bytespider|AmazonBot|AhrefsBot|BaiduSpider|Jooblebot|NetSpider) ) {
+    return 410;
     }
+
 
     ssl_certificate /etc/letsencrypt/live/${PATH}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${PATH}/privkey.pem;
@@ -40,8 +41,8 @@ server {
     listen 80;
     server_name ${DOMAIN};
 
-    if ($http_user_agent ~ ".*SEMrushBot.*") {
-      return 301 "http://semrush.com/";
+    if ($http_user_agent ~* (thesis-research-bot|Bytespider|AmazonBot|AhrefsBot|BaiduSpider|Jooblebot|NetSpider) ) {
+    return 410;
     }
 
     location / {

--- a/templates/vhost.sample.conf
+++ b/templates/vhost.sample.conf
@@ -2,9 +2,9 @@ server {
     listen 443 ssl http2;
     server_name ${DOMAIN} www.${DOMAIN};
 
-    if ($http_user_agent ~ ".*SEMrushBot.*") {
-      return 301 "http://semrush.com/";
-    }
+    if ($http_user_agent ~* (Bytespider|AmazonBot|AhrefsBot|BaiduSpider|Jooblebot|NetSpider) ) {
+    return 410;
+    }    
 
     ssl_certificate /etc/ssl/certs/${PATH}/fullchain.crt;
     ssl_certificate_key /etc/ssl/certs/${PATH}/privkey.key;


### PR DESCRIPTION
   refactor: harden entrypoint and update SSL root chain
    
    - Added cleanup for /var/run/fail2ban/fail2ban.sock to prevent restart failures.
    - Ensured Nginx logs exist before Fail2Ban starts to prevent service crashes.
    - Updated Let's Encrypt preferred-chain to ISRG Root X1 (replacing expired DST Root).
    - Optimized domain array processing using IFS.
    - Replaced manual backgrounding with `exec` for better Docker signal handling.